### PR TITLE
fix: no exported member 'ComponentInstance' and dependencies update

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,22 +1,30 @@
 {
   "name": "stencil-click-outside",
-  "version": "1.0.0",
+  "version": "1.4.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
     "@stencil/core": {
-      "version": "1.0.0-beta.8",
-      "resolved": "http://fe-artifactoryha.de.bosch.com:80/artifactory/api/npm/npm-repo/@stencil/core/-/core-1.0.0-beta.8.tgz",
-      "integrity": "sha1-NNyoQEmDQKYsdXHa6M9u28tO5Io=",
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@stencil/core/-/core-1.2.1.tgz",
+      "integrity": "sha512-aXwwWVPsX2nqMXQm4S6zxZAKxYCAuR3VnIHejWJZSUsqhCjeS6TQzNkPEEQy54LGZrTZb9xHYxKmPiakuUpV9Q==",
       "dev": true,
       "requires": {
-        "typescript": "3.5.1"
+        "typescript": "3.5.3"
+      },
+      "dependencies": {
+        "typescript": {
+          "version": "3.5.3",
+          "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.5.3.tgz",
+          "integrity": "sha512-ACzBtm/PhXBDId6a6sDJfroT2pOWt/oOnk4/dElG5G33ZL776N3Y6/6bKZJBFpd+b05F3Ct9qDjMeJmRWtE2/g==",
+          "dev": true
+        }
       }
     },
     "typescript": {
-      "version": "3.5.1",
-      "resolved": "http://fe-artifactoryha.de.bosch.com:80/artifactory/api/npm/npm-repo/typescript/-/typescript-3.5.1.tgz",
-      "integrity": "sha1-unKmpgCyFYE5xd2IUPcA4jFGQgI=",
+      "version": "3.5.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.5.3.tgz",
+      "integrity": "sha512-ACzBtm/PhXBDId6a6sDJfroT2pOWt/oOnk4/dElG5G33ZL776N3Y6/6bKZJBFpd+b05F3Ct9qDjMeJmRWtE2/g==",
       "dev": true
     }
   }

--- a/package.json
+++ b/package.json
@@ -12,11 +12,11 @@
   },
   "dependencies": {},
   "devDependencies": {
-    "@stencil/core": "^1.0.0",
-    "typescript": "^3.4.4"
+    "@stencil/core": "^1.2.1",
+    "typescript": "^3.5.3"
   },
   "peerDependencies": {
-    "@stencil/core": "^1.0.0"
+    "@stencil/core": "^1.2.1"
   },
   "repository": {
     "type": "git",

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,9 +1,9 @@
 import { getElement } from "@stencil/core";
-import { ComponentInstance } from "@stencil/core/dist/declarations";
+import { ComponentInterface } from "@stencil/core/dist/declarations";
 import { BUILD } from "@stencil/core/build-conditionals";
 
 declare type ClickOutsideDecorator = (
-  target: ComponentInstance,
+  target: ComponentInterface,
   propertyKey: string
 ) => void;
 
@@ -30,7 +30,7 @@ callback() {
 export function ClickOutside(
   opt: ClickOutsideOptions = ClickOutsideOptionsDefaults
 ): ClickOutsideDecorator {
-  return (proto: ComponentInstance, methodName: string) => {
+  return (proto: ComponentInterface, methodName: string) => {
     // this is to resolve the 'compiler optimization issue':
     // lifecycle events not being called when not explicitly declared in at least one of components from bundle
     BUILD.cmpDidLoad = true;
@@ -58,14 +58,14 @@ export function ClickOutside(
  * Register callback function for HTMLElement to be executed when user clicks outside of element.
  * @example
 ```
-<span 
+<span
     ref={spanEl => registerClickOutside(this, spanEl, () => this.test())}>
       Hello, World!
 </span>;
 ```
  */
 export function registerClickOutside(
-  component: ComponentInstance,
+  component: ComponentInterface,
   element: HTMLElement,
   callback: () => void,
   opt: ClickOutsideOptions = ClickOutsideOptionsDefaults
@@ -86,7 +86,7 @@ export function registerClickOutside(
  * Remove click outside callback function for HTMLElement.
  */
 export function removeClickOutside(
-  component: ComponentInstance,
+  component: ComponentInterface,
   element: HTMLElement,
   callback: () => void,
   opt: ClickOutsideOptions = ClickOutsideOptionsDefaults
@@ -104,7 +104,7 @@ export function removeClickOutside(
 
 function initClickOutside(
   event: Event,
-  component: ComponentInstance,
+  component: ComponentInterface,
   element: HTMLElement,
   callback: () => void,
   excludedNodes?: Array<HTMLElement>


### PR DESCRIPTION
Hi @jarrvis,
I'm providing here the fix for the error I've mentioned on this [issue](https://github.com/jarrvis/stencil-click-outside/issues/2) and took the chance also to update the dependencies on the `package.json` 😉 