### PR TITLE
fix: `ComponentInterface` and `Build` import path & npm dependencies update

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "stencil-click-outside",
-  "version": "1.5.0",
+  "version": "1.6.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,26 +5,18 @@
   "requires": true,
   "dependencies": {
     "@stencil/core": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/@stencil/core/-/core-1.2.1.tgz",
-      "integrity": "sha512-aXwwWVPsX2nqMXQm4S6zxZAKxYCAuR3VnIHejWJZSUsqhCjeS6TQzNkPEEQy54LGZrTZb9xHYxKmPiakuUpV9Q==",
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/@stencil/core/-/core-1.9.0.tgz",
+      "integrity": "sha512-GebQiDqR04owD1NkCVDYUQduQIPdIsGW7K70hmuW1KLrWURdaaECQeBQJOAE1pasZMg8vYoSRFt3LeCE7nsJAQ==",
       "dev": true,
       "requires": {
-        "typescript": "3.5.3"
-      },
-      "dependencies": {
-        "typescript": {
-          "version": "3.5.3",
-          "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.5.3.tgz",
-          "integrity": "sha512-ACzBtm/PhXBDId6a6sDJfroT2pOWt/oOnk4/dElG5G33ZL776N3Y6/6bKZJBFpd+b05F3Ct9qDjMeJmRWtE2/g==",
-          "dev": true
-        }
+        "typescript": "3.8.3"
       }
     },
     "typescript": {
-      "version": "3.5.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.5.3.tgz",
-      "integrity": "sha512-ACzBtm/PhXBDId6a6sDJfroT2pOWt/oOnk4/dElG5G33ZL776N3Y6/6bKZJBFpd+b05F3Ct9qDjMeJmRWtE2/g==",
+      "version": "3.8.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.8.3.tgz",
+      "integrity": "sha512-MYlEfn5VrLNsgudQTVJeNaQFUAI7DkhnOjdpAp4T+ku1TfQClewlbSuTVHiA+8skNBgaf02TL/kLOvig4y3G8w==",
       "dev": true
     }
   }

--- a/package.json
+++ b/package.json
@@ -12,8 +12,8 @@
   },
   "dependencies": {},
   "devDependencies": {
-    "@stencil/core": "^1.2.1",
-    "typescript": "^3.5.3"
+    "@stencil/core": "^1.9.0",
+    "typescript": "^3.8.3"
   },
   "peerDependencies": {
     "@stencil/core": "^1.2.1"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "stencil-click-outside",
-  "version": "1.5.0",
+  "version": "1.6.0",
   "description": "Decorator for StencilJs to run annotated method on click outside of component.",
   "main": "dist/index.js",
   "module": "dist/esm/index.js",

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,4 @@
-import { getElement } from "@stencil/core";
-import { ComponentInterface } from "@stencil/core/dist/declarations";
-import { BUILD } from "@stencil/core/build-conditionals";
+import { Build as BUILD, ComponentInterface, getElement } from '@stencil/core';
 
 declare type ClickOutsideDecorator = (
   target: ComponentInterface,
@@ -33,8 +31,8 @@ export function ClickOutside(
   return (proto: ComponentInterface, methodName: string) => {
     // this is to resolve the 'compiler optimization issue':
     // lifecycle events not being called when not explicitly declared in at least one of components from bundle
-    BUILD.cmpDidLoad = true;
-    BUILD.cmpDidUnload = true;
+    (BUILD as any).cmpDidLoad = true;
+    (BUILD as any).cmpDidUnload = true;
 
     const { componentDidLoad, componentDidUnload } = proto;
 


### PR DESCRIPTION
Hi there @jarrvis  🙂, 
I'm providing here a small pull request for fixing some import path issues appearing withing the latest stencil v1.9.0 (recently released) and updating the dependencies on the package.json (version bumped included)